### PR TITLE
Dynamic Item Details Page

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -14,7 +14,7 @@ function App() {
         <Route path="/" element={<Home />} />
         <Route path="/explore" element={<Explore />} />
         <Route path="/author/:authorId" element={<Author />} />
-        <Route path="/item-details" element={<ItemDetails />} />
+        <Route path="/item-details/:itemId" element={<ItemDetails />} />
       </Routes>
       <Footer />
     </Router>

--- a/src/components/author/AuthorItems.jsx
+++ b/src/components/author/AuthorItems.jsx
@@ -38,7 +38,7 @@ const AuthorItems = ({ authorImage, nftCollection, loading }) => {
                         </div>
                       </div>
                     </div>
-                    <Link to="/item-details">
+                    <Link to={`/item-details/${item.nftId}`}>
                       <img
                         src={item.nftImage}
                         className="lazy nft__item_preview"

--- a/src/pages/ItemDetails.jsx
+++ b/src/pages/ItemDetails.jsx
@@ -16,7 +16,6 @@ const ItemDetails = () => {
     );
     setItemData(data);
     setLoading(false);
-    console.log(data);
   }
 
   useEffect(() => {
@@ -33,7 +32,7 @@ const ItemDetails = () => {
   return (
     <div id="wrapper">
       <div className="no-bottom no-top" id="content">
-        {loading && (
+        {!loading && (
           <>
             <div id="top"></div>
             <section aria-label="section" className="mt90 sm-mt-0">
@@ -122,7 +121,7 @@ const ItemDetails = () => {
           </>
         )}
 
-        {!loading && (
+        {loading && (
           <>
             <div id="top"></div>
             <section aria-label="section" className="mt90 sm-mt-0">

--- a/src/pages/ItemDetails.jsx
+++ b/src/pages/ItemDetails.jsx
@@ -1,91 +1,202 @@
-import React, { useEffect } from "react";
+import React, { useEffect, useState } from "react";
 import EthImage from "../images/ethereum.svg";
-import { Link } from "react-router-dom";
-import AuthorImage from "../images/author_thumbnail.jpg";
-import nftImage from "../images/nftImage.jpg";
+import { Link, useParams } from "react-router-dom";
+import axios from "axios";
+import Skeleton from "../components/UI/Skeleton";
 
 const ItemDetails = () => {
+  const { itemId } = useParams();
+
+  const [itemData, setItemData] = useState({});
+  const [loading, setLoading] = useState(false);
+
+  async function fetchApi() {
+    const { data } = await axios.get(
+      `https://us-central1-nft-cloud-functions.cloudfunctions.net/itemDetails?nftId=${itemId}`
+    );
+    setItemData(data);
+    setLoading(false);
+    console.log(data);
+  }
+
   useEffect(() => {
     window.scrollTo(0, 0);
-  }, []);
+    setLoading(true);
+    fetchApi();
+
+    return () => {
+      setLoading(false);
+      setItemData({});
+    };
+  }, [itemId]);
 
   return (
     <div id="wrapper">
       <div className="no-bottom no-top" id="content">
-        <div id="top"></div>
-        <section aria-label="section" className="mt90 sm-mt-0">
-          <div className="container">
-            <div className="row">
-              <div className="col-md-6 text-center">
-                <img
-                  src={nftImage}
-                  className="img-fluid img-rounded mb-sm-30 nft-image"
-                  alt=""
-                />
-              </div>
-              <div className="col-md-6">
-                <div className="item_info">
-                  <h2>Rainbow Style #194</h2>
+        {loading && (
+          <>
+            <div id="top"></div>
+            <section aria-label="section" className="mt90 sm-mt-0">
+              <div className="container">
+                <div className="row">
+                  <div className="col-md-6 text-center">
+                    <img
+                      src={itemData?.nftImage}
+                      className="img-fluid img-rounded mb-sm-30 nft-image"
+                      alt=""
+                    />
+                  </div>
+                  <div className="col-md-6">
+                    <div className="item_info">
+                      <h2>
+                        {itemData?.title} #{itemData?.tag}
+                      </h2>
 
-                  <div className="item_info_counts">
-                    <div className="item_info_views">
-                      <i className="fa fa-eye"></i>
-                      100
-                    </div>
-                    <div className="item_info_like">
-                      <i className="fa fa-heart"></i>
-                      74
-                    </div>
-                  </div>
-                  <p>
-                    doloremque laudantium, totam rem aperiam, eaque ipsa quae ab
-                    illo inventore veritatis et quasi architecto beatae vitae
-                    dicta sunt explicabo.
-                  </p>
-                  <div className="d-flex flex-row">
-                    <div className="mr40">
-                      <h6>Owner</h6>
-                      <div className="item_author">
-                        <div className="author_list_pp">
-                          <Link to="/author">
-                            <img className="lazy" src={AuthorImage} alt="" />
-                            <i className="fa fa-check"></i>
-                          </Link>
+                      <div className="item_info_counts">
+                        <div className="item_info_views">
+                          <i className="fa fa-eye"></i>
+                          {itemData?.views}
                         </div>
-                        <div className="author_list_info">
-                          <Link to="/author">Monica Lucas</Link>
+                        <div className="item_info_like">
+                          <i className="fa fa-heart"></i>
+                          {itemData?.likes}
                         </div>
                       </div>
-                    </div>
-                    <div></div>
-                  </div>
-                  <div className="de_tab tab_simple">
-                    <div className="de_tab_content">
-                      <h6>Creator</h6>
-                      <div className="item_author">
-                        <div className="author_list_pp">
-                          <Link to="/author">
-                            <img className="lazy" src={AuthorImage} alt="" />
-                            <i className="fa fa-check"></i>
-                          </Link>
+                      <p>{itemData?.description}</p>
+                      <div className="d-flex flex-row">
+                        <div className="mr40">
+                          <h6>Owner</h6>
+                          <div className="item_author">
+                            <div className="author_list_pp">
+                              <Link to={`/author/${itemData?.ownerId}`}>
+                                <img
+                                  className="lazy"
+                                  src={itemData?.ownerImage}
+                                  alt=""
+                                />
+                                <i className="fa fa-check"></i>
+                              </Link>
+                            </div>
+                            <div className="author_list_info">
+                              <Link to={`/author/${itemData?.ownerId}`}>
+                                {itemData.ownerName}
+                              </Link>
+                            </div>
+                          </div>
                         </div>
-                        <div className="author_list_info">
-                          <Link to="/author">Monica Lucas</Link>
+                        <div></div>
+                      </div>
+                      <div className="de_tab tab_simple">
+                        <div className="de_tab_content">
+                          <h6>Creator</h6>
+                          <div className="item_author">
+                            <div className="author_list_pp">
+                              <Link to={`/author/${itemData?.creatorId}`}>
+                                <img
+                                  className="lazy"
+                                  src={itemData?.creatorImage}
+                                  alt=""
+                                />
+                                <i className="fa fa-check"></i>
+                              </Link>
+                            </div>
+                            <div className="author_list_info">
+                              <Link to={`/author/${itemData?.creatorId}`}>
+                                {itemData?.creatorName}
+                              </Link>
+                            </div>
+                          </div>
+                        </div>
+                        <div className="spacer-40"></div>
+                        <h6>Price</h6>
+                        <div className="nft-item-price">
+                          <img src={EthImage} alt="" />
+                          <span>{itemData.price}</span>
                         </div>
                       </div>
-                    </div>
-                    <div className="spacer-40"></div>
-                    <h6>Price</h6>
-                    <div className="nft-item-price">
-                      <img src={EthImage} alt="" />
-                      <span>1.85</span>
                     </div>
                   </div>
                 </div>
               </div>
-            </div>
-          </div>
-        </section>
+            </section>
+          </>
+        )}
+
+        {!loading && (
+          <>
+            <div id="top"></div>
+            <section aria-label="section" className="mt90 sm-mt-0">
+              <div className="container">
+                <div className="row">
+                  <div className="col-md-6 text-center">
+                    <Skeleton width="100%" height="500px" />
+                  </div>
+                  <div className="col-md-6">
+                    <div className="item_info">
+                      <h2>
+                        <Skeleton width="300px" />
+                      </h2>
+
+                      <div className="item_info_counts">
+                        <Skeleton width="80px" height="30px" />
+                        <Skeleton width="80px" height="30px" />
+                      </div>
+                      <Skeleton width="100%" height="100px" />
+                      <div className="d-flex flex-row">
+                        <div className="mr40">
+                          <h6>Owner</h6>
+                          <div className="item_author">
+                            <div className="author_list_pp">
+                              <Link to="">
+                                <Skeleton
+                                  width="50px"
+                                  height="50px"
+                                  borderRadius="50%"
+                                />
+                              </Link>
+                            </div>
+                            <div className="author_list_info">
+                              <Link to="">
+                                <Skeleton width="120px" height="20px" />
+                              </Link>
+                            </div>
+                          </div>
+                        </div>
+                        <div></div>
+                      </div>
+                      <div className="de_tab tab_simple">
+                        <div className="de_tab_content">
+                          <h6>Creator</h6>
+                          <div className="item_author">
+                            <div className="author_list_pp">
+                              <Link to="">
+                                <Skeleton
+                                  width="50px"
+                                  height="50px"
+                                  borderRadius="50%"
+                                />
+                              </Link>
+                            </div>
+                            <div className="author_list_info">
+                              <Link to="">
+                                <Skeleton width="120px" height="20px" />
+                              </Link>
+                            </div>
+                          </div>
+                        </div>
+                        <div className="spacer-40"></div>
+                        <h6>Price</h6>
+                        <div className="nft-item-price">
+                          <Skeleton width="80px" height="18px" />
+                        </div>
+                      </div>
+                    </div>
+                  </div>
+                </div>
+              </div>
+            </section>
+          </>
+        )}
       </div>
     </div>
   );


### PR DESCRIPTION
**Task:** 
Make Items Details Page dynamic

**Why:**
Currently, the Item Details Page is dummy data

**How:**
Used Axios to pull data from the backend and display it on the page

**Before:**
![image](https://user-images.githubusercontent.com/82671183/216653745-b9dc5fc8-9c76-4e07-9508-3b306093c6d4.png)

**After:**
![image](https://user-images.githubusercontent.com/82671183/216653931-8b5392fd-f6b4-47b9-9842-8a4a7bd34a87.png)
